### PR TITLE
Add a set-up script for setting up the work environment

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+while getopts ":c:" opt; do
+  case $opt in
+    c) comp="$OPTARG"
+    ;;
+    \?) echo "Invalid option -$OPTARG" >&2
+    exit 1
+    ;;
+  esac
+
+  case $OPTARG in
+    -*) echo "Option $opt needs a valid argument"
+    exit 1
+    ;;
+  esac
+done
+
+echo "Compiler selected: $comp"
+
+./blst/build.sh CC=$comp -mcpu=cortex-m33 flavour=elf -fno-pie
+ret=$?
+
+if [ $ret -eq 0 ];
+then
+echo "Blst library builded"
+rm -f ./cli/include/blst.h
+rm -f ./cli/include/blst_aux.h
+rm -f ./cli/lib/libblst.a
+mkdir -p ./cli/lib
+mv ./libblst.a ./cli/lib/
+mkdir -p ./cli/include
+cp ./blst/bindings/blst.h ./blst/bindings/blst_aux.h ./cli/include/
+
+else
+echo "Error building blst library"
+
+fi


### PR DESCRIPTION
New set-up script for setting up the work environment. You can run it using the following command:
`./setup.sh -c /some/where//toolchain/opt/gcc-arm-none-eabi-10-2020-q4-major/bin/arm-none-eabi-gcc-10.2.1`

The script needs to be tested and is able to be improved.